### PR TITLE
Dark water

### DIFF
--- a/components/water-background.tsx
+++ b/components/water-background.tsx
@@ -56,7 +56,7 @@ const WaterBackground = () => {
           float r = abs(sin(uv.x - uv.y));
           
           // Add subtle blue highlights
-          color += vec3(0.0, 0.05, 0.075) * r;
+          color += vec3(0.0, 0.10, 0.15) * r;
 
           gl_FragColor = vec4(color, 1.0);
         }

--- a/components/water-background.tsx
+++ b/components/water-background.tsx
@@ -46,7 +46,7 @@ const WaterBackground = () => {
 
           // Water ripple effect
           float t = u_time * 0.1;
-          vec2 uv = st * (u_resolution.x < 600.0 ? 20.0 : 10.0); // Scale uv based on screen width
+          vec2 uv = st * 10.0; 
           
           for(float i = 1.0; i < 3.0; i++){
             uv.y += i * 0.15 * sin(uv.x * i * 0.5 + t * i);
@@ -56,7 +56,7 @@ const WaterBackground = () => {
           float r = abs(sin(uv.x - uv.y));
           
           // Add subtle blue highlights
-          color += vec3(0.0, 0.10, 0.15) * r;
+          color += vec3(0.0, 0.05, 0.075) * r;
 
           gl_FragColor = vec4(color, 1.0);
         }


### PR DESCRIPTION
For water background - removes the additional lines for screens <600px. We tried a darker water color but ended up back at the same color. Reducing the number of lines made phone UX better.